### PR TITLE
Fixed file size limitation problem in GitHub's Content API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cffi==1.8.3
 cryptography==1.5.2
 enum34==1.0.4
-github3.py==0.9.4
+github3.py==0.9.6
 gspread==0.2.5
 httplib2==0.9.2
 idna==2.0


### PR DESCRIPTION
Fixes #25 

Can't use the Content API due to the 1MB file size limitation: https://developer.github.com/v3/repos/contents/

I had to do it the complicated way instead 😢 
- the Branches API to get `sha` of the target branch
- and then the Trees API to get `Tree` of the target branch
- and then find `sha` of our target file (e.g., `sessions.json`)
- and then the Blobs API to grab content of `sessions.json`

For more details, see inline comments in `update_schedule.py`
